### PR TITLE
Fix custom assertion example

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ custom assertions or override the built-in ones:
 expect.configure({
   // expect(2).to.be.even();
   even: function() {
-    QUnit.ok(this._actual % 2, 'expected ' + this._actual + ' to be even');
+    QUnit.ok(!(this._actual % 2), 'expected ' + this._actual + ' to be even');
   }
 });
 ```

--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -453,7 +453,7 @@
    *   expect.configure({
    *     // expect(2).to.be.even();
    *     even: function() {
-   *       QUnit.ok(this._actual % 2, 'expected ' + this._actual + ' to be even');
+   *       QUnit.ok(!(this._actual % 2), 'expected ' + this._actual + ' to be even');
    *     }
    *   });
    *

--- a/test/qunit-bdd_test.js
+++ b/test/qunit-bdd_test.js
@@ -241,11 +241,14 @@ describe('expect', function() {
   describe('.configure', function() {
     it('allows augmenting the default expect assertion', function() {
       var assertion = expect();
-      expect(assertion.clown).not.to.be.defined();
-      expect.configure({ clown: function(){ this.equal('clown'); } });
-      expect(typeof assertion.clown).to.equal('function');
-      expect.configure({ clown: undefined });
-      expect(typeof assertion.clown).to.equal('undefined');
+      expect(assertion.even).not.to.be.defined();
+      expect.configure({ even: function(){
+        QUnit.ok(!(this._actual % 2), 'expected ' + this._actual + ' to be even');
+      } });
+      expect(2).to.be.even();
+      expect(typeof assertion.even).to.equal('function');
+      expect.configure({ even: undefined });
+      expect(typeof assertion.even).to.equal('undefined');
     });
 
     if (Object.defineProperty) {


### PR DESCRIPTION
The custom assertion example is backwards, it was failing for even numbers.
