### PR TITLE
Fixes #6: naked expect(N) behaves like QUnit.expect(N)

### DIFF
--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -400,30 +400,12 @@
   function Assertion(actual) {
     this._actual = actual;
     this._flags = {};
-    /**
-     * Syntactic sugar to help readability:
-     *
-     *   // This doesn't read very nicely.
-     *   expect(1).equal(1);
-     *
-     *   // But this does.
-     *   expect(1).to.equal(1);
-     *
-     * @return {Assertion}
-     */
-    this.to = this;
-    /**
-     * Syntactic sugar to help readability:
-     *
-     *   // This doesn't read very nicely.
-     *   expect(true).true();
-     *
-     *   // But this does.
-     *   expect(true).to.be.true();
-     *
-     * @return {Assertion}
-     */
-    this.be = this;
+    this._prevExpectedAssertions = QUnit.config.current.expected;
+
+    if (typeof actual === 'number') {
+      QUnit.config.current.expected = actual;
+    }
+
     Object.defineProperties(this, {
       /**
        * Negates the meaning of this assertion.
@@ -433,88 +415,49 @@
        * @return {Assertion}
        */
       not: {
-        get: function() {
-          this._flags.negate = !this._flags.negate;
-          return this;
-        }
+        get: negateAssertionGetter
+      },
+      /**
+       * Syntactic sugar to help readability:
+       *
+       *   // This doesn't read very nicely.
+       *   expect(1).equal(1);
+       *
+       *   // But this does.
+       *   expect(1).to.equal(1);
+       *
+       * @return {Assertion}
+       */
+      to: {
+        get: identityAssertionGetter
+      },
+      /**
+       * Syntactic sugar to help readability:
+       *
+       *   // This doesn't read very nicely.
+       *   expect(true).true();
+       *
+       *   // But this does.
+       *   expect(true).to.be.true();
+       *
+       * @return {Assertion}
+       */
+      be: {
+        get: identityAssertionGetter
       }
     });
   }
 
-  /**
-   * Asserts that the actual and expected values are (or are not) equal. This
-   * method checks using strict equality (===) and delegates to
-   * QUnit.(not)strictEqual.
-   *
-   * @param {*} expected
-   * @param {?string} message
-   */
-  Assertion.prototype.equal = function(expected, message) {
-    if (this._flags.negate) {
-      QUnit.notStrictEqual(this._actual, expected, message);
-    } else {
-      QUnit.strictEqual(this._actual, expected, message);
-    }
-  };
+  function identityAssertionGetter() {
+    QUnit.config.current.expected = this._prevExpectedAssertions;
+    return this;
+  }
 
-  /**
-   * Asserts that the actual and expected values are (or are not) deeply equal.
-   * This method checks that object keys and values match up, recursively. This
-   * method delegates to QUnit.(not)deepEqual.
-   *
-   * @param {*} expected
-   * @param {?string} message
-   */
-  Assertion.prototype.eql = function(expected, message) {
-    if (this._flags.negate) {
-      QUnit.notDeepEqual(this._actual, expected, message);
-    } else {
-      QUnit.deepEqual(this._actual, expected, message);
-    }
-  };
-
-  /**
-   * Asserts that the actual value is (or is not) undefined.
-   */
-  Assertion.prototype.undefined = function() {
-    this.equal(void 0);
-  };
-
-  /**
-   * Asserts that the actual value is (or is not) null.
-   */
-  Assertion.prototype.null = function() {
-    this.equal(null);
-  };
-
-  /**
-   * Asserts that the actual value is (or is not) false.
-   */
-  Assertion.prototype.false = function() {
-    this.equal(false);
-  };
-
-  /**
-   * Asserts that the actual value is (or is not) true.
-   */
-  Assertion.prototype.true = function() {
-    this.equal(true);
-  };
-
-  /**
-   * Asserts that the actual value is (or is not) null or undefined.
-   */
-  Assertion.prototype.defined = function(message) {
-    if (this._flags.negate) {
-      QUnit.push(
-        this._actual === null || this._actual === undefined,
-        this._actual, undefined, message);
-    } else {
-      QUnit.push(
-        this._actual !== null && this._actual !== undefined,
-        this._actual, undefined, message);
-    }
-  };
+  function negateAssertionGetter() {
+    QUnit.config.current.expected = this._prevExpectedAssertions;
+    this._flags.negate = !this._flags.negate;
+    return this;
+  }
 
   /**
    * Creates a new Assertion.
@@ -544,13 +487,107 @@
         var descriptor = Object.getOwnPropertyDescriptor(assertions, key);
         if (descriptor) {
           descriptor.configurable = true;
+          if (descriptor.get) {
+            descriptor.get = assertionWrapper(descriptor.get);
+          } else {
+            descriptor.value = assertionWrapper(descriptor.value);
+          }
           Object.defineProperty(Assertion.prototype, key, descriptor);
         }
       } else if (assertions.hasOwnProperty(key)) {
-        Assertion.prototype[key] = assertions[key];
+        Assertion.prototype[key] = assertionWrapper(assertions[key]);
       }
     }
   };
+
+  function assertionWrapper(fn) {
+    if (typeof fn === 'undefined') {
+      // Unsetting the assertion
+      return undefined;
+    }
+
+    return function() {
+      QUnit.config.current.expected = this._prevExpectedAssertions;
+      return fn.apply(this, arguments);
+    };
+  }
+
+  expect.configure({
+    /**
+     * Asserts that the actual and expected values are (or are not) equal. This
+     * method checks using strict equality (===) and delegates to
+     * QUnit.(not)strictEqual.
+     *
+     * @param {*} expected
+     * @param {?string} message
+     */
+    equal: function(expected, message) {
+      if (this._flags.negate) {
+        QUnit.notStrictEqual(this._actual, expected, message);
+      } else {
+        QUnit.strictEqual(this._actual, expected, message);
+      }
+    },
+
+    /**
+     * Asserts that the actual and expected values are (or are not) deeply equal.
+     * This method checks that object keys and values match up, recursively. This
+     * method delegates to QUnit.(not)deepEqual.
+     *
+     * @param {*} expected
+     * @param {?string} message
+     */
+    eql: function(expected, message) {
+      if (this._flags.negate) {
+        QUnit.notDeepEqual(this._actual, expected, message);
+      } else {
+        QUnit.deepEqual(this._actual, expected, message);
+      }
+    },
+
+    /**
+     * Asserts that the actual value is (or is not) undefined.
+     */
+    undefined: function() {
+      this.equal(void 0);
+    },
+
+    /**
+     * Asserts that the actual value is (or is not) null.
+     */
+    null: function() {
+      this.equal(null);
+    },
+
+    /**
+     * Asserts that the actual value is (or is not) false.
+     */
+    false: function() {
+      this.equal(false);
+    },
+
+    /**
+     * Asserts that the actual value is (or is not) true.
+     */
+    true: function() {
+      this.equal(true);
+    },
+
+    /**
+     * Asserts that the actual value is (or is not) null or undefined.
+     */
+    defined: function(message) {
+      if (this._flags.negate) {
+        QUnit.push(
+          this._actual === null || this._actual === undefined,
+          this._actual, undefined, message);
+      } else {
+        QUnit.push(
+          this._actual !== null && this._actual !== undefined,
+          this._actual, undefined, message);
+      }
+    }
+  });
 
   /**
    * Fails a test unconditionally with the given message.

--- a/test/qunit-bdd_test.js
+++ b/test/qunit-bdd_test.js
@@ -117,6 +117,29 @@ describe('fail', function() {
 });
 
 describe('expect', function() {
+  describe('QUnit.expect delegation', function() {
+    it('behaves like QUnit.expect if no accessors are called on the expect() object', function() {
+      expect(3);
+      QUnit.equal(QUnit.config.current.expected, 3);
+      expect(1);
+    });
+
+    it('it does not override the expected assertion count if .to or .be is called', function() {
+      expect(3).to.equal(3);
+      QUnit.equal(QUnit.config.current.expected, null);
+      expect(3).to;
+      QUnit.equal(QUnit.config.current.expected, null);
+      expect(3).be;
+      QUnit.equal(QUnit.config.current.expected, null);
+    });
+
+    it('it does not override the expected assertion count if default assertions are called', function() {
+      QUnit.expect(2);
+      expect(1).equal(1);
+      QUnit.equal(QUnit.config.current.expected, 2);
+    });
+  });
+
   describe('.to', function() {
     it('is purely syntactic sugar', function() {
       var expectation = expect(0);


### PR DESCRIPTION
Now you can do 

``` js
it('does stuff', function() {
  expect(2);
  ok(true);
  ok(true);
});
```

Previously, `expect(2)` was being interpreted as an expectation assertion rather than the vanilla QUnit behavior of setting the expected assertion count.
