### PR TITLE
Allow lazy values to be overridden in tests

### DIFF
--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -408,6 +408,10 @@
             cached = true;
           }
           return value;
+        },
+        set: function(newValue) {
+          cached = true;
+          value = newValue;
         }
       });
     });

--- a/test/qunit-bdd_test.js
+++ b/test/qunit-bdd_test.js
@@ -434,6 +434,11 @@ describe('lazy', function() {
     it('makes the lazy value available as a property on the execution context', function() {
       expect(this.name).to.equal('Brian');
     });
+
+    it('can be overridden', function() {
+      this.name = "Alex";
+      expect(this.name).to.equal('Alex');
+    });
   });
 
   context('with a dynamic value', function() {
@@ -441,6 +446,11 @@ describe('lazy', function() {
 
     it('makes the lazy value available as a property on the execution context', function() {
       expect(this.name).to.equal('Madeline');
+    });
+
+    it('can be overridden', function() {
+      this.name = "Alex";
+      expect(this.name).to.equal('Alex');
     });
   });
 


### PR DESCRIPTION
Previously you'd get an error if you tried to do

```
this.lazyValue = "some new thing for this test";
```

Now you can.
