### PR TITLE
Handle exceptions in bdd hooks.

### DIFF
--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -61,7 +61,13 @@
     var parent = this.parent;
 
     this[hook].forEach(function(fn) {
-      queue.push(function() { fn.call(env); });
+      queue.push(function() {
+        try {
+          fn.call(env);
+        } catch (e) {
+          QUnit.pushFailure( "Exception while running qunit-bdd hook: " + ( e.message || e ) );
+        }
+      });
     });
 
     if (parent) {


### PR DESCRIPTION
Without this an exception in a before hook (for example) would cause tests to hang.
