### PR TITLE
better assertion messages; update qunit npm dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -6,6 +6,21 @@
     throw new Error('Unable to locate QUnit! Please load it before qunit-bdd.');
   }
 
+  function slice(args) {
+    return [].slice.apply(args);
+  }
+
+  /*
+    call an original QUnit function while preserving the
+    number of arguments originally given. This is used to
+    make sure that QUnit sees the right # of arguments
+    and uses better default error messages.
+  */
+  function callOriginal(originalFn, actual, restArgs, context) {
+    var args = [actual].concat(slice(restArgs));
+    originalFn.apply(context || QUnit, args);
+  }
+
   /**
    * Represents an execution context for tests created by calls to `describe`
    * and `context`. Contexts can be nested inside each other.
@@ -609,9 +624,9 @@
     equal: {
       value: function(expected, message) {
         if (this._flags.negate) {
-          QUnit.notStrictEqual(this._actual, expected, message);
+          callOriginal(QUnit.notStrictEqual, this._actual, arguments);
         } else {
-          QUnit.strictEqual(this._actual, expected, message);
+          callOriginal(QUnit.strictEqual, this._actual, arguments);
         }
       }
     },
@@ -627,9 +642,9 @@
     eql: {
       value: function(expected, message) {
         if (this._flags.negate) {
-          QUnit.notDeepEqual(this._actual, expected, message);
+          callOriginal(QUnit.notDeepEqual, this._actual, arguments);
         } else {
-          QUnit.deepEqual(this._actual, expected, message);
+          callOriginal(QUnit.deepEqual, this._actual, arguments);
         }
       }
     },
@@ -639,7 +654,7 @@
      */
     undefined: {
       value: function(message) {
-        this.equal(void 0, message);
+        callOriginal(this.equal, void 0, arguments, this);
       }
     },
 
@@ -648,7 +663,7 @@
      */
     null: {
       value: function(message) {
-        this.equal(null, message);
+        callOriginal(this.equal, null, arguments, this);
       }
     },
 
@@ -657,7 +672,7 @@
      */
     false: {
       value: function(message) {
-        this.equal(false, message);
+        callOriginal(this.equal, false, arguments, this);
       }
     },
 
@@ -666,7 +681,7 @@
      */
     true: {
       value: function(message) {
-        this.equal(true, message);
+        callOriginal(this.equal, true, arguments, this);
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "Apache 2",
   "devDependencies": {
     "karma": "^0.12.6",
-    "qunitjs": "~1.12.0",
+    "qunitjs": "~1.14.0",
     "karma-qunit": "^0.1.1",
     "karma-phantomjs-launcher": "^0.1.4"
   }

--- a/test/qunit-bdd_test.js
+++ b/test/qunit-bdd_test.js
@@ -176,6 +176,13 @@ describe('expect', function() {
 
       expect(strictEqualStub.firstCall.args[2]).to.equal('math works');
     });
+
+    it('passes the right number of arguments if message not passed', function(){
+      var strictEqualStub = sinon.stub(QUnit, 'strictEqual');
+      expect(1 + 1).to.equal(2);
+      strictEqualStub.restore();
+      expect(strictEqualStub.firstCall.args.length).to.equal(2);
+    });
   });
 
   describe('.not.equal', function() {
@@ -197,6 +204,13 @@ describe('expect', function() {
       notStrictEqualStub.restore();
 
       expect(notStrictEqualStub.firstCall.args[2]).to.equal('math does not work');
+    });
+
+    it('passes the right number of arguments if message not passed', function(){
+      var notStrictEqualStub = sinon.stub(QUnit, 'notStrictEqual');
+      expect(1 + 1).to.not.equal(2);
+      notStrictEqualStub.restore();
+      expect(notStrictEqualStub.firstCall.args.length).to.equal(2);
     });
   });
 
@@ -221,6 +235,13 @@ describe('expect', function() {
       deepEqualStub.restore();
 
       expect(deepEqualStub.firstCall.args[2]).to.equal('keys and values match');
+    });
+
+    it('passes the right number of arguments if message not passed', function(){
+      var deepEqualStub = sinon.stub(QUnit, 'deepEqual');
+      expect(1 + 1).to.eql(2);
+      deepEqualStub.restore();
+      expect(deepEqualStub.firstCall.args.length).to.equal(2);
     });
   });
 
@@ -308,6 +329,14 @@ describe('expect', function() {
 
       expect(strictEqualStub.firstCall.args[2]).to.equal('tautology');
     });
+
+    it('passes the right number of arguments if message not passed', function(){
+      var strictEqualStub = sinon.stub(QUnit, 'strictEqual');
+      expect(null).to.be['null']();
+      strictEqualStub.restore();
+
+      expect(strictEqualStub.firstCall.args.length).to.equal(2);
+    });
   });
 
   describe('.true', function() {
@@ -318,6 +347,14 @@ describe('expect', function() {
 
       expect(strictEqualStub.firstCall.args[2]).to.equal('tautology');
     });
+
+    it('passes the right number of arguments if message not passed', function(){
+      var strictEqualStub = sinon.stub(QUnit, 'strictEqual');
+      expect(true).to.be['true']();
+      strictEqualStub.restore();
+
+      expect(strictEqualStub.firstCall.args.length).to.equal(2);
+    });
   });
 
   describe('.false', function() {
@@ -327,6 +364,14 @@ describe('expect', function() {
       strictEqualStub.restore();
 
       expect(strictEqualStub.firstCall.args[2]).to.equal('tautology');
+    });
+
+    it('passes the right number of arguments if message not passed', function(){
+      var strictEqualStub = sinon.stub(QUnit, 'strictEqual');
+      expect(false).to.be['false']()
+      strictEqualStub.restore();
+
+      expect(strictEqualStub.firstCall.args.length).to.equal(2);
     });
   });
 


### PR DESCRIPTION
Previously, when you wrote the following in your code,
your assertion message would just show up as "undefined".

expect(1).to.equal(2);

Now, the right amount of arguments are passed to the
original QUnit functions so you'll now get an error
from QUnit by default like:

"expected 2, actual 1"
