### PR TITLE
Add clickable error messages in chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ request, we'll make sure you're in the list of people who have signed a CLA.
 
 ### Why?
 
-QUnit is a well-tested testing framework used projects such as jQuery and
+QUnit is a well-tested testing framework used by projects such as jQuery and
 Ember. It works very well for unit-style testing with fairly simple inputs and
 outputs. It is less well suited to acceptance or integration testing, where you
 often want to test slight variations of the same thing. The nested context of

--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -68,6 +68,7 @@
           try {
             fn.call(env);
           } catch (e) {
+            e.stack && console.warn(e.stack);
             QUnit.pushFailure(
               'Exception while running qunit-bdd `' + hook + '` hook: ' +
               (e.message || e),
@@ -270,7 +271,14 @@
     }
     context.tests.push({
       description: description,
-      body: body
+      body: function() {
+        try {
+          body.call(this);
+        } catch (e) {
+          e.stack && console.warn(e.stack);
+          throw e;
+        }
+      }
     });
   }
 


### PR DESCRIPTION
This makes clickable error messages in `before()` and `it()` blocks in chrome to make debugging much simpler.

**it() block error**
![image](https://cloud.githubusercontent.com/assets/412371/15722937/fe290024-27f4-11e6-90f0-36cc6d648d0f.png)

**before() block error**
![image](https://cloud.githubusercontent.com/assets/412371/15722976/2f72b36e-27f5-11e6-8c50-434c54306a6a.png)
