### PR TITLE
Add async support to `before` and `after`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ $ git clone https://github.com/square/qunit-bdd.git
 $ cp qunit-bdd/lib/qunit-bdd.js my-project/vendor/qunit-bdd.js
 ```
 
+In addition to installing qunit-bdd, you must install QUnit itself. Currently,
+qunit-bdd is known to work with QUnit v1.23.1 and above in the v1.x line. It
+has not been tested with QUnit v2.x. Please report any bugs in the issues.
+
 ### Usage
 
 qunit-bdd has `describe` and `context`, just like Mocha and Jasmine. It also
@@ -154,6 +158,35 @@ describe('APIRequest', function() {
   it('works in another context', function() {
     // ... test-specific setup
     this.fireApiRequest();
+  });
+});
+```
+
+#### Async
+
+qunit-bdd supports `async` functions as `before`, `after`, or `it` callbacks.
+You may also return `Promise` objects from `before`, `after`, and `it` blocks as
+a means of writing async tests. We rely on QUnit's own mechanism for this
+functionality, which means we require at leastd QUnit v1.16. Here's a basic
+example:
+
+```js
+describe('delay', function() {
+  it('returns a promise that resolves after Nms', async function() {
+    await delay(10);
+    ok(true, 'promise resolved!');
+  });
+});
+```
+
+You can write this using explicit `Promise` syntax if you prefer:
+
+```js
+describe('delay', function() {
+  it('returns a promise that resolves after Nms', function() {
+    return delay(10).then(() => {
+      ok(true, 'promise resolved!');
+    });
   });
 });
 ```

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'node_modules/es6-promise/dist/es6-promise.js',
       'test/preconfig.js',
       'lib/**/*.js',
       'test/vendor/sinon.js',

--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -63,11 +63,14 @@
     this[hook].forEach(function(fn) {
       queue.push(function() {
         if (QUnit.config.notrycatch) {
-          fn.call(env);
+          QUnit.config.current.resolvePromise(fn.call(env));
         } else {
           try {
-            fn.call(env);
+            QUnit.config.current.resolvePromise(fn.call(env));
           } catch (e) {
+            if (e.stack) {
+              console.error(e.stack);
+            }
             QUnit.pushFailure(
               'Exception while running qunit-bdd `' + hook + '` hook: ' +
               (e.message || e),

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
   "author": "Brian Donovan",
   "license": "Apache-2.0",
   "devDependencies": {
+    "es6-promise": "^4.1.0",
     "karma": "^0.12.6",
     "karma-phantomjs-launcher": "^1.0.4",
-    "karma-qunit": "^0.1.1",
-    "qunitjs": "~1.14.0"
+    "karma-qunit": "^1.2.1",
+    "qunitjs": "^1.23.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/"

--- a/test/preconfig.js
+++ b/test/preconfig.js
@@ -6,3 +6,6 @@ QUnit.config.urlConfig.push({
 var QUNIT_BDD_OPTIONS = {
   randomize: QUnit.urlParams.randomize
 };
+
+// Polyfill using es6-promise.
+window.Promise = window.ES6Promise;


### PR DESCRIPTION
Previously we simply ignored the return value from `before` and `after` callbacks. Now we use QUnit's `resolvePromise` test helper with the result that pauses the test runner until the promise resolves or rejects.