### PR TITLE
remove getAssert/setAssert and rely on QUnit.config.current.assert

### DIFF
--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -93,20 +93,6 @@
     QUnit.config.queue.unshift.apply(QUnit.config.queue, queue);
   };
 
-  /**
-   * @param {QUnit.Assert} assert
-   */
-  Context.prototype.setAssert = function(assert) {
-    this.assert = assert;
-  };
-
-  /**
-   * @return {QUnit.Assert}
-   */
-  Context.prototype.getAssert = function() {
-    return this.assert;
-  };
-
 
   /**
    * Context state data. The root context handles top-level `before` and
@@ -227,7 +213,6 @@
 
       tests.forEach(function(test) {
         function body(assert) {
-          currentContext().setAssert(assert);
           return test.body.call(this, assert);
         }
         body.skipped = test.body.skipped;
@@ -516,7 +501,7 @@
    * @return {Assertion}
    */
   function expect(actual) {
-    var assertion = new Assertion(actual, currentContext().getAssert());
+    var assertion = new Assertion(actual, QUnit.config.current.assert);
 
     Object.defineProperty(assertion, '_previousExpectedAssertions', {
       value: QUnit.config.current.expected,
@@ -720,7 +705,7 @@
    * @param {string} message
    */
   function fail(message) {
-    currentContext().getAssert().ok(false, message);
+    QUnit.config.current.assert.ok(false, message);
   }
 
   /**


### PR DESCRIPTION
Accessing the current qunit test directly allows using `expect()` without calling `it()` first. Should you ever do that? Probably not. But Square has many tests that use `expect` with `module`/`test` for some reason.