### PR TITLE
fix: disallow calling DSL methods during test runs

### DIFF
--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -245,6 +245,12 @@
     options.randomize :
     shuffle;
 
+  function assertDSLMethodCallable(method) {
+    if (QUnit.config.current) {
+      throw new Error('cannot call `' + method + '` within a running test');
+    }
+  }
+
   // Add test suites just before QUnit starts running.
   QUnit.begin(addTestsToQUnit);
 
@@ -256,12 +262,27 @@
    * @param {?object} options
    */
   function describe(description, body, options) {
+    assertDSLMethodCallable('describe');
+
     var desc = new Context(description, currentContext(), options);
 
     pendingContexts.push(desc);
     contextStack.push(desc);
     body.call(desc);
     contextStack.pop();
+  }
+
+  /**
+   * Creates a context and adds it to the current context state.
+   *
+   * @param {string} description
+   * @param {function(this: Context)} body
+   * @param {?object} options
+   * @alias describe
+   */
+  function context(description, body, options) {
+    assertDSLMethodCallable('context');
+    describe(description, body, options);
   }
 
   /**
@@ -272,6 +293,8 @@
    * @param {boolean} skipped
    */
   function it(description, body, /* internal */ skipped) {
+    assertDSLMethodCallable('it');
+
     var context = currentContext();
     if (context.skipped || skipped) {
       description += ' (SKIPPED)';
@@ -308,20 +331,60 @@
    * @param {string} description
    * @param {function()} body
    */
-  describe.skip = function(description, body) {
-    describe(description, body, { skipped: true });
-  };
+  describe.skip = makeSkip(describe);
 
-  describe.only = function(description, body) {
-    var module = currentContext().fullDescription();
-    if (module) {
-      module += ' ' + description;
-    } else {
-      module = description;
-    }
-    QUnit.config.module = module;
-    describe(description, body);
-  };
+  /**
+   * Configures QUnit to run only tests defined within this `describe`.
+   *
+   * @param {string} description
+   * @param {function()} body
+   */
+  describe.only = makeOnly(describe);
+
+
+  /**
+   * Allows leaving a `context` in place but having QUnit skip all the tests,
+   * as if you'd annotated all of them with `.skip` instead.
+   *
+   * @param {string} description
+   * @param {function()} body
+   */
+  context.skip = makeSkip(context);
+
+  /**
+   * Configures QUnit to run only tests defined within this `context`.
+   *
+   * @param {string} description
+   * @param {function()} body
+   */
+  context.only = makeOnly(context);
+
+  /**
+   * @param {function(string, function(), *)} method
+   * @returns {function(string, function())}
+   */
+  function makeSkip(method) {
+    return function(description, body) {
+      method(description, body, { skipped: true });
+    };
+  }
+
+  /**
+   * @param {function(string, function(), *)} method
+   * @returns {function(string, function())}
+   */
+  function makeOnly(method) {
+    return function(description, body) {
+      var module = currentContext().fullDescription();
+      if (module) {
+        module += ' ' + description;
+      } else {
+        module = description;
+      }
+      QUnit.config.module = module;
+      method(description, body);
+    };
+  }
 
   /**
    * Allows leaving a test intact but without it being run. It will be marked
@@ -357,6 +420,7 @@
    * @param {function()} body
    */
   function before(body) {
+    assertDSLMethodCallable('before');
     currentContext().before.push(body);
   }
 
@@ -367,6 +431,7 @@
    * @param {function()} body
    */
   function after(body) {
+    assertDSLMethodCallable('after');
     currentContext().after.push(body);
   }
 
@@ -397,6 +462,7 @@
    * @param {function()} body
    */
   function helper(name, fn) {
+    assertDSLMethodCallable('helper');
     lazy(name, function() { return fn; });
   }
 
@@ -443,6 +509,8 @@
    * @param {*} value
    */
   function lazy(name, value) {
+    assertDSLMethodCallable('lazy');
+
     var cached = false;
     var getter;
 
@@ -741,7 +809,7 @@
 
   doExports({
     describe: describe,
-    context: describe,
+    context: context,
     it: it,
     before: before,
     after: after,


### PR DESCRIPTION
Such tests will not be run but appear to work. This causes such calls to fail immediately.