### PR TITLE
build: include type declarations for TypeScript

### DIFF
--- a/lib/qunit-bdd.d.ts
+++ b/lib/qunit-bdd.d.ts
@@ -1,0 +1,73 @@
+/// <reference types="qunit" />
+
+declare namespace QUnitBDD {
+  export type TestContext = object;
+
+  export type DescribeCallback = {
+    (): void | Promise<void>;
+    (assert: Assert): void | Promise<void>;
+  };
+
+  export type TestCallback = {
+    (this: TestContext): void | Promise<void>;
+    (this: TestContext, assert: Assert): void | Promise<void>;
+  };
+
+  export type Describe = {
+    (description: string, body: DescribeCallback): void;
+    skip(description: string, body: DescribeCallback): void;
+    only(description: string, body: DescribeCallback): void;
+  };
+
+  export type TestMethod = {
+    (this: Context, description: string, body: TestCallback): void;
+    skip(this: Context, description: string, body: TestCallback): void;
+    only(this: Context, description: string, body: TestCallback): void;
+  };
+
+  export type Lazy<T> = {
+    (name: string, factory: (this: TestContext) => T): void;
+    (name: string, value: T): void;
+  };
+
+  export type Helper<T> = (name: string, method: (this: TestContext) => T) => void;
+  export type Before = (this: Context, body: TestCallback) => void;
+  export type After = (this: Context, body: TestCallback) => void;
+  export type Fail = (message: string) => void;
+  export type Expect<T> = (value: T) => Expectation<T>;
+
+  export interface Expectation<T> {
+    to: this;
+    not: this;
+    be: this;
+    equal(expected: T, message?: string): void;
+    eql(expected: T, message?: string): void;
+    undefined(message?: string): void;
+    null(message?: string): void;
+    false(message?: string): void;
+    true(message?: string): void;
+    defined(message?: string): void;
+  }
+}
+
+declare module 'qunit-bdd' {
+  export const describe: QUnitBDD.Describe;
+  export const context: QUnitBDD.Describe;
+  export const it: QUnitBDD.TestMethod;
+  export const lazy: QUnitBDD.Lazy<any>;
+  export const helper: QUnitBDD.Helper<any>;
+  export const before: QUnitBDD.Before;
+  export const after: QUnitBDD.After;
+  export const fail: QUnitBDD.Fail;
+  export const expect: QUnitBDD.Expect<any>;
+}
+
+declare const describe: QUnitBDD.Describe;
+declare const context: QUnitBDD.Describe;
+declare const it: QUnitBDD.TestMethod;
+declare const lazy: QUnitBDD.Lazy<any>;
+declare const helper: QUnitBDD.Helper<any>;
+declare const before: QUnitBDD.Before;
+declare const after: QUnitBDD.After;
+declare const fail: QUnitBDD.Fail;
+declare const expect: QUnitBDD.Expect<any>;

--- a/package.json
+++ b/package.json
@@ -3,15 +3,17 @@
   "version": "2.0.1",
   "description": "BDD-style testing for QUnit.",
   "main": "lib/qunit-bdd.js",
+  "types": "lib/qunit-bdd.d.ts",
   "directories": {
     "test": "test"
   },
   "files": [
     "lib/qunit-bdd.js",
+    "lib/qunit-bdd.d.ts",
     "LICENSE"
   ],
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . && tsc lib/qunit-bdd.d.ts",
     "pretest": "yarn run lint",
     "test": "yarn run test-node && yarn run test-browser",
     "test-node": "env TARGET=node ./script/ci",
@@ -29,6 +31,7 @@
   "author": "Brian Donovan",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/qunit": "^2.0.31",
     "es6-promise": "^4.1.0",
     "eslint": "^3.19.0",
     "karma": "^1.7.0",
@@ -36,7 +39,8 @@
     "karma-qunit": "^1.2.1",
     "qunit-cli": "^0.2.0",
     "qunitjs": "^2.3.3",
-    "sinon": "^2.3.2"
+    "sinon": "^2.3.2",
+    "typescript": "^2.3.4"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/qunit@^2.0.31":
+  version "2.0.31"
+  resolved "https://registry.npmjs.org/@types/qunit/-/qunit-2.0.31.tgz#a53e2cf635262c8bf46a71a137d8c7970dde9562"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -2016,15 +2020,9 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@1.3.2:
+resolve@1.3.2, resolve@^1.1.6:
   version "1.3.2"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
-  dependencies:
-    path-parse "^1.0.5"
-
-resolve@^1.1.6:
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
     path-parse "^1.0.5"
 
@@ -2334,6 +2332,10 @@ type-is@~1.6.15:
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz#3d38321828231e434f287514959c37a82b629f42"
 
 uid-number@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
This allows TypeScript users to use qunit-bdd more easily.