### PR TITLE
Add `>` to delineate nested context descriptions

### DIFF
--- a/lib/qunit-bdd.js
+++ b/lib/qunit-bdd.js
@@ -58,7 +58,7 @@ void function(global, exports, QUnit, options) {
     if (this.parent) {
       var parentDescription = this.parent.fullDescription();
       if (parentDescription) {
-        return parentDescription + ' ' + this.description;
+        return parentDescription + ' > ' + this.description;
       }
     }
     return this.description;

--- a/test/qunit-bdd_test.js
+++ b/test/qunit-bdd_test.js
@@ -34,7 +34,7 @@ describe('describe', function() {
     });
 
     it('has a full description which contains all parent descriptions prepended', function() {
-      expect(executionContext.fullDescription()).to.equal('describe execution context');
+      expect(executionContext.fullDescription()).to.equal('describe > execution context');
     });
 
     it('has a reference to the parent execution context', function() {


### PR DESCRIPTION
This helps to quickly parse where the descriptions of the parent and child start and end.